### PR TITLE
Remove dependency on Postgres for testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,20 +28,21 @@
   },
   "homepage": "https://github.com/thebergamo/k7-sequelize#readme",
   "dependencies": {
-    "glob": "7.0.x",
-    "hoek": "3.0.x",
+    "glob": "7.x.x",
+    "hoek": "4.x.x",
     "k7": "1.x.x",
+    "lab": "10.x.x",
     "mysql": "2.x.x",
-    "pg": "4.x.x",
+    "pg": "6.x.x",
     "pg-hstore": "2.x.x",
-    "sequelize": "3.x.x",
+    "sequelize": "4.0.0-0",
     "sqlite3": "3.x.x",
     "tedious": "1.x.x"
   },
   "devDependencies": {
-    "code": "2.x.x",
-    "hapi": "10.x.x",
+    "code": "3.x.x",
+    "hapi": "14.x.x",
     "lab": "10.x.x",
-    "semistandard": "7.x.x"
+    "semistandard": "8.x.x"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -10,7 +10,6 @@ const Path = require('path');
 // Load example
 
 const K7Sequelize = require('../lib');
-const url = require('url');
 
 // Test shortcuts
 
@@ -22,12 +21,11 @@ const before = lab.before;
 
 describe('K7Sequelize', () => {
   let options = {
-    connectionString: buildUri(),
     models: 'test/models/*.js',
     adapter: K7Sequelize,
     connectionOptions: {
       options: {
-        dialect: 'postgres'
+        dialect: 'sqlite'
       }
     }
   };
@@ -54,11 +52,11 @@ describe('K7Sequelize', () => {
 
       // Instance of K7 should be registered
 
-      expect(server).to.deep.include('database');
+      expect(server).to.include('database');
       expect(server.database).to.be.an.object();
-      expect(server.database).to.deep.include('sequelize');
-      expect(server.database).to.deep.include('Sequelize');
-      expect(server.database).to.deep.include('User');
+      expect(server.database).to.include('sequelize');
+      expect(server.database).to.include('Sequelize');
+      expect(server.database).to.include('User');
       done();
     });
 
@@ -96,11 +94,11 @@ describe('K7Sequelize', () => {
 
       // Instance of K7 should be registered
 
-      expect(server).to.deep.include('database');
+      expect(server).to.include('database');
       expect(server.database).to.be.an.object();
-      expect(server.database).to.deep.include('sequelize');
-      expect(server.database).to.deep.include('Sequelize');
-      expect(server.database).to.deep.include('User');
+      expect(server.database).to.include('sequelize');
+      expect(server.database).to.include('Sequelize');
+      expect(server.database).to.include('User');
       done();
     });
 
@@ -140,11 +138,11 @@ describe('K7Sequelize', () => {
 
       // Instance of K7 should be registered
 
-      expect(server).to.deep.include('database');
+      expect(server).to.include('database');
       expect(server.database).to.be.an.object();
-      expect(server.database).to.deep.include('sequelize');
-      expect(server.database).to.deep.include('Sequelize');
-      expect(server.database).to.deep.include('User');
+      expect(server.database).to.include('sequelize');
+      expect(server.database).to.include('Sequelize');
+      expect(server.database).to.include('User');
       done();
     });
 
@@ -212,16 +210,3 @@ describe('K7Sequelize', () => {
     });
   });
 });
-
-function buildUri () {
-  let username = process.env.DB_USERNAME || 'postgres';
-  let password = process.env.DB_PASSWORD || 'postgres';
-  return url.format({
-    protocol: 'postgresql',
-    slashes: true,
-    auth: username + ':' + password,
-    port: process.env.DB_PORT || 5432,
-    hostname: process.env.DB_HOST || 'localhost',
-    pathname: process.env.DB_NAME || 'project'
-  });
-}


### PR DESCRIPTION
I took care of updating all dependencies and refactoring testing to use SQLite in memory rather than Postgres, allowing much better test portability.
