### PR TITLE
Fixed done callback in load()

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -58,7 +58,7 @@ module.exports = internals.K7Sequelize = function (options) {
   this.db['Sequelize'] = Sequelize;
 };
 
-internals.K7Sequelize.prototype.load = function () {
+internals.K7Sequelize.prototype.load = function (done) {
   let sequelize;
   if (this.settings.connectionString) {
     sequelize = new Sequelize(this.settings.connectionString, this.settings.connectionOptions);
@@ -77,7 +77,7 @@ internals.K7Sequelize.prototype.load = function () {
   this.db['sequelize'] = sequelize;
   this.db['Sequelize'] = Sequelize;
 
-  return this.db;
+  return done(null, this.db);
 };
 
 internals.K7Sequelize.prototype.getModels = function () {


### PR DESCRIPTION
The `load()` function wasn't calling the `done` callback in the end and the k7 Loader wasn't being able to attach the db to hapi server instance.

Will require a patch version bump if accepted.