### PR TITLE
Change connection options format

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -17,35 +17,33 @@ internals.defaults = {
     database: null,
     username: null,
     password: null,
-    options: {
-      host: 'localhost',
-      port: null,
-      dialect: 'mysql',
-      dialectModulePath: null,
-      dialectOptions: null,
-      storage: null,
-      protocol: 'tcp',
-      query: null,
-      set: null,
-      sync: null,
-      timezone: '+00:00',
-      logging: console.log,
-      omitNull: false,
-      native: false,
-      replication: false,
-      pool: {
-        maxConnections: null,
-        minConnections: null,
-        maxIdleTime: null,
-        validateConnection: null
-      },
-      quoteIdentifiers: true,
-      transactionType: 'DEFERRED',
-      isolationLevel: 'REPEATABLE_READ',
-      retry: null,
-      typeValidation: false,
-      benchmark: false
-    }
+    host: 'localhost',
+    port: null,
+    dialect: 'mysql',
+    dialectModulePath: null,
+    dialectOptions: null,
+    storage: null,
+    protocol: 'tcp',
+    query: null,
+    set: null,
+    sync: null,
+    timezone: '+00:00',
+    logging: console.log,
+    omitNull: false,
+    native: false,
+    replication: false,
+    pool: {
+      maxConnections: null,
+      minConnections: null,
+      maxIdleTime: null,
+      validateConnection: null
+    },
+    quoteIdentifiers: true,
+    transactionType: 'DEFERRED',
+    isolationLevel: 'REPEATABLE_READ',
+    retry: null,
+    typeValidation: false,
+    benchmark: false
   },
   models: ['models/**.js']
 };
@@ -66,7 +64,7 @@ internals.K7Sequelize.prototype.load = function () {
     sequelize = new Sequelize(this.settings.connectionOptions.database,
                               this.settings.connectionOptions.username,
                               this.settings.connectionOptions.password,
-                              this.settings.connectionOptions.options);
+                              this.settings.connectionOptions);
   }
 
   this.sequelize = sequelize;

--- a/test/index.js
+++ b/test/index.js
@@ -24,9 +24,7 @@ describe('K7Sequelize', () => {
     models: 'test/models/*.js',
     adapter: K7Sequelize,
     connectionOptions: {
-      options: {
-        dialect: 'sqlite'
-      }
+      dialect: 'sqlite'
     }
   };
 


### PR DESCRIPTION
First, this is not a fix. This is just a matter of style. 

I'm not aware of the other adapters, but in the official [express-sequelize](https://github.com/sequelize/express-example/blob/master/models/index.js#L11) (generated by `sequelize-cli`) the options parameter is the whole options itself. Why? Because it avoid adding a nested `options` child to the object. Why? The `sequelize-cli` generates a `config.json` with the following data:

```json
{
  "development": {
    "dialect": "sqlite",
    "storage": "./db.development.sqlite"
  },
  "test": {
    "dialect": "sqlite",
    "storage": ":memory:"
  },
  "production": {
    "username": "root",
    "password": null,
    "database": "database_production",
    "host": "127.0.0.1",
    "dialect": "mysql"
  }
}
```

Pretty straightforward. There's no separation of `username`, `password` and `database`from the other values. In the end they are all options to the configuration. Why? I had to read the adapter's code to understand that I had to pass the `options` object instead of just passing the data `sequelize-cli` generated. Of course this confusion could be solved adding an example to the README too.

What do you think?

**PS: If you decide to accept this, let me rebase this with the other code from the PR I opened fixing the `load` and tests.**

Will require a minor version bump if accepted.